### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/sys/arch/i486/arch-kerninc/db_machdep.h
+++ b/src/sys/arch/i486/arch-kerninc/db_machdep.h
@@ -94,8 +94,15 @@ extern db_regs_t	ddb_regs;	/* register state */
 #define	inst_call(ins)		(((ins)&0xff) == I_CALL || \
 				 (((ins)&0xff) == I_CALLI && \
 				  ((ins)&0x3800) == 0x1000))
-#define inst_load(ins)		0
-#define inst_store(ins)		0
+
+INLINE int inst_load(db_expr_t ins) {
+   (void)ins;  // to avoid a compiler warning
+   return 0;
+}
+INLINE int inst_store(db_expr_t ins) {
+   (void)ins;
+   return 0;
+}
 
 /* access capability and access macros */
 

--- a/src/sys/arch/i486/ddb/db_trace.c
+++ b/src/sys/arch/i486/ddb/db_trace.c
@@ -269,12 +269,15 @@ db_stack_trace_cmd(db_expr_t addr, int have_addr,
 
   lastframe = 0;
   while (count && frame != 0) {
+#if 0
     int		narg;
+    const char **argnp = NULL;
+#define MAXNARG	16
+    const char	*argnames[MAXNARG];
+#endif
     const char *	name;
     db_expr_t	offset;
     db_sym_t	sym;
-#define MAXNARG	16
-    const char	*argnames[MAXNARG], **argnp = NULL;
 
     sym = db_search_symbol(callpc, DB_STGY_ANY, &offset);
     db_symbol_values(sym, &name, NULL);
@@ -338,15 +341,15 @@ db_stack_trace_cmd(db_expr_t addr, int have_addr,
 #endif
       else
 	goto normal;
+#if 0
       narg = 0;
+#endif
     } else {
     normal:
       is_trap = NONE;
+#if 0
       narg = MAXNARG;
-      if (db_sym_numargs(sym, &narg, argnames))
-	argnp = argnames;
-      else
-	narg = db_numargs(frame);
+#endif
     }
 
 #if 0
@@ -363,8 +366,6 @@ db_stack_trace_cmd(db_expr_t addr, int have_addr,
     }
 
     while (narg) {
-      if (argnp)
-	db_printf("%s=", *argnp++);
       db_printf("%x", db_get_value((int)argp + userSpaceOffset, 4, false));
       argp++;
       if (--narg != 0)

--- a/src/sys/kernel/kern_Node.c
+++ b/src/sys/kernel/kern_Node.c
@@ -247,7 +247,7 @@ node_PrepAsSegment(Node* thisPtr)
   return true;
 }
 
-inline bool
+bool
 node_IsCurrentDomain(Node* thisPtr)
 {
   /* Note proc_Current() may be NULL.  If we are trying to

--- a/src/sys/kernel/kern_PhysMem.c
+++ b/src/sys/kernel/kern_PhysMem.c
@@ -510,7 +510,7 @@ physMem_Alloc(kpsize_t nBytes, PmemConstraint *mc)
       const kpa_t split = align_up(base, EROS_PAGE_SIZE);
       if (split < allocTarget->allocBound) {
         /* Split the region */
-        PmemInfo * newPmi;
+        PmemInfo * newPmi = NULL;
 #if 0
         printf("Splitting: 0x%x 0x%x 0x%x 0x%x\n",
                        (unsigned)allocTarget->allocBase,
@@ -523,6 +523,7 @@ physMem_Alloc(kpsize_t nBytes, PmemConstraint *mc)
         ret = physMem_AddRegion(split, allocTarget->allocBound,
                                 MI_MEMORY, &newPmi);
         assert(!ret);
+        assert(newPmi);
         newPmi->allocBase = max(split, where + nBytes);
         allocTarget->bound = split;
         allocTarget->allocBound = where;


### PR DESCRIPTION
Define i486 inst_load and inst_store as INLINE to avoid warning about unused parameter.
Fix various other compilation warnings.