### PR TITLE
Fix compilation errors and drop support for big-endian targets.

### DIFF
--- a/src/base/host/bin/lsvol/prt_ckdir.c
+++ b/src/base/host/bin/lsvol/prt_ckdir.c
@@ -40,8 +40,8 @@ showProcs(uint8_t * p, unsigned int num)
     struct DiskProcessDescriptor dpd;
     memcpy(&dpd, dpdp, sizeof(struct DiskProcessDescriptor));
 
-    diag_printf("OID=%#llx cc=%#x",
-                get_target_oid(&dpd.oid), dpd.callCount);
+    diag_printf("OID=%#" PRIxOID " cc=%#x",
+                GetDiskProcessDescriptorOid(&dpd), dpd.callCount);
     if (dpd.actHazard) {
       diag_printf(" haz=%d\n", dpd.actHazard);
     } else {

--- a/src/base/host/lib/erosimg/Volume.c
+++ b/src/base/host/lib/erosimg/Volume.c
@@ -1360,7 +1360,7 @@ vol_GetPagePotInfo(Volume *pVol, OID oid, VolPagePot *pPot)
   if (cpd) {
     pPot->count = cpd->allocCount;
     pPot->type = cpd->type;
-    pPot->isZero = CONTENT_LID(get_target_lid(&cpd->logLoc)) ? 0 : TagIsZero;
+    pPot->isZero = CONTENT_LID(GetDiskObjectDescriptorLogLoc(cpd)) ? 0 : TagIsZero;
 
     return true;
   }
@@ -1401,7 +1401,7 @@ vol_ReadDataPage(Volume *pVol, OID oid, uint8_t *buf)
   cpd = vol_LookupObject(pVol, oid);
     
   if (cpd) {
-    LID lid = get_target_lid(&cpd->logLoc);
+    LID lid = GetDiskObjectDescriptorLogLoc(cpd);
     assert (CONTENT_LID(lid));
     return vol_ReadLogPage(pVol, lid, buf);
   }
@@ -1457,7 +1457,7 @@ vol_WriteDataPage(Volume *pVol, OID oid, const uint8_t *buf)
   /* If a location has already been fabricated, write it there even if
    * it is a zero page.
    */
-  LID lid = get_target_lid(&cpd->logLoc);
+  LID lid = GetDiskObjectDescriptorLogLoc(cpd);
   if ( cpd && CONTENT_LID(lid) ) {
     return vol_WriteLogPage(pVol, lid, buf);
   }
@@ -1636,9 +1636,9 @@ vol_ReadNode(Volume * pVol, OID oid, DiskNode * pNode)
 {
   int div;
   CkptDirent* ccd = vol_LookupObject(pVol, oid);
-  LID lid = get_target_lid(&ccd->logLoc);
     
   if (ccd && ccd->type == FRM_TYPE_NODE) {
+    LID lid = GetDiskObjectDescriptorLogLoc(ccd);
     uint32_t i;
     uint8_t logPage[EROS_PAGE_SIZE];
     DiskNode * logPot = (DiskNode *) logPage;
@@ -1710,7 +1710,7 @@ bool
 vol_WriteNode(Volume *pVol, OID oid, const DiskNode * pNode)
 {
   CkptDirent* ccd = vol_LookupObject(pVol, oid);
-  LID lid = get_target_lid(&ccd->logLoc);
+  LID lid = GetDiskObjectDescriptorLogLoc(ccd);
   int div;
     
   if (ccd && ccd->type != FRM_TYPE_NODE)

--- a/src/sys/disk/DiskObjDescr.h
+++ b/src/sys/disk/DiskObjDescr.h
@@ -24,6 +24,7 @@ Research Projects Agency under Contract No. W31P4Q-07-C-0070.
 Approved for public release, distribution unlimited. */
 
 #include <disk/ErosTypes.h>
+#include <string.h>
 
 // struct DiskObjectDescriptor is packed because
 // (1) it needs to be the same on the host and target, and
@@ -38,5 +39,14 @@ struct DiskObjectDescriptor {
   uint8_t   type;		/**<The type of the object. */
 } __attribute__ ((packed));
 typedef struct DiskObjectDescriptor DiskObjectDescriptor;
+
+INLINE LID 
+GetDiskObjectDescriptorLogLoc(const DiskObjectDescriptor * dod)
+{
+  // Must use memcpy since DiskObjectDescriptor is packed.
+  LID_s lid;
+  memcpy(&lid, &dod->logLoc, sizeof(lid));
+  return get_target_lid(&lid);
+}
 
 #endif /* _DISKOBJDESCR_H */

--- a/src/sys/disk/GenerationHdr.h
+++ b/src/sys/disk/GenerationHdr.h
@@ -25,6 +25,7 @@ Approved for public release, distribution unlimited. */
 
 #include <eros/target.h>
 #include <disk/ErosTypes.h>
+#include <string.h>
 
 struct GenDirHdr {
   LID_s firstDirFrame;
@@ -58,5 +59,14 @@ struct DiskProcessDescriptor {
   ObCount callCount;
   uint8_t actHazard;
 } __attribute__ ((packed));
+
+INLINE OID 
+GetDiskProcessDescriptorOid(const struct DiskProcessDescriptor * dpd)
+{
+  // Must use memcpy since DiskProcessDescriptor is packed.
+  OID_s oids;
+  memcpy(&oids, &dpd->oid, sizeof(oids));
+  return get_target_oid(&oids);
+}
 
 #endif // __GENERATIONHDR_H__

--- a/src/sys/eros/arch/arm/Makefile
+++ b/src/sys/eros/arch/arm/Makefile
@@ -38,11 +38,11 @@ LOCAL_HEADERS=\
 	atomic.h \
 	cap-instr.h \
 	DevPrivs.h \
+	endian.h \
 	Invoke.h \
 	IORQ.h \
 	IRQSWI.h \
 	SWI.h \
-	endian.h \
 	StackPtr.h \
 	target-asm.h \
 

--- a/src/sys/eros/arch/i486/Makefile
+++ b/src/sys/eros/arch/i486/Makefile
@@ -39,9 +39,9 @@ LOCAL_HEADERS=\
 	atomic.h \
 	cap-instr.h \
 	DevPrivs.h \
+	endian.h \
 	Invoke.h \
 	IORQ.h \
-	endian.h \
 	StackPtr.h \
 	target-asm.h \
 	io.h \


### PR DESCRIPTION
Add GetDiskObjectDescriptorLogLoc() and GetDiskProcessDescriptorOid() to read unaligned data using memcpy.