### PR TITLE
Change Symbol.raises from PtrVec to vector<Symbol*>.

### DIFF
--- a/src/build/make/build-rules.mk
+++ b/src/build/make/build-rules.mk
@@ -29,7 +29,9 @@ endif
 
 # The following variables depend on things set in the makefile:
 GCCFLAGS=$(CFLAGS) $(GCC_OPTIM) $(OPTIM) $(INC) -DEROS_TARGET_$(EROS_TARGET) -DCAPROS_MACH_$(CAPROS_MACH) $(DEF)
-GPLUSFLAGS=-fdefault-inline -fno-implicit-templates $(GPLUS_OPTIM) $(OPTIM) $(INC) -DEROS_TARGET_$(EROS_TARGET) $(DEF)
+GPLUSFLAGS=-fdefault-inline $(GPLUS_OPTIM) $(OPTIM) $(INC) -DEROS_TARGET_$(EROS_TARGET) $(DEF)
+# The following does not work for capidl:
+# GPLUSFLAGS+= -fno-implicit-templates
 GPLUSFLAGS+= -fpermissive	# for now
 MKIMAGEFLAGS=-a $(EROS_TARGET) -DBUILDDIR='"$(BUILDDIR)/"' -DEROS_TARGET_$(EROS_TARGET) -DLIBDIR=\"$(CAPROS_DOMAIN)/\" -DCAPROS_LOCALDIR=$(CAPROS_LOCALDIR) -I$(CAPROS_DOMAIN) -I$(EROS_ROOT)/host/include $(LINUXINC)
 

--- a/src/build/src/capidl/SymTab.h
+++ b/src/build/src/capidl/SymTab.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
  * Copyright (C) 2008, Strawberry Development Group.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the CapROS Operating System runtime library,
  * and is derived from the EROS Operating System runtime library.
@@ -24,6 +25,7 @@ Research Projects Agency under Contract No. W31P4Q-07-C-0070.
 Approved for public release, distribution unlimited. */
 
 #include <applib/PtrVec.h>
+#include <vector>
 
 #define ENUMERAL_SIZE    4
 #define TARGET_LONG_SIZE 4
@@ -71,35 +73,35 @@ typedef enum SymClass SymClass;
 #define SF_NOSTUB     0x1u
 #define SF_NO_OPCODE  0x2u
 
-typedef struct Symbol Symbol;
-struct Symbol {
+class Symbol {
+public:
+  // Constructor
+  Symbol(const char *nm, bool isActiveUOC, SymClass sc);
+
   InternedString name;
 #ifdef SYMDEBUG
   InternedString qualifiedName;
 #endif
-  InternedString docComment;
+  InternedString docComment = nullptr;  /* unknown type */
 
-  bool           mark;		/* used for circularity detection */
+  bool           mark = false;		/* used for circularity detection */
   bool           isActiveUOC;	/* created in an active unit of compilation */
 
-  Symbol         *nameSpace;	/* containing namespace */
+  Symbol         *nameSpace = nullptr;	/* containing namespace */
   PtrVec         *children;	/* members of the scope */
-  PtrVec         *raises;	/* exceptions raised by this method/interface */
-#if 0
-  Symbol         *next;		/* in same scope */
-  Symbol         *children;
-#endif
+  std::vector<Symbol*> raised;	/* exceptions raised by this method/interface */
 
   SymClass       cls;
 
-  Symbol *       type;		/* type of an identifier */
-  Symbol *       baseType;	/* base type, if extension */
-  Symbol *       value;		/* value of a constant */
+  Symbol *       type = nullptr;		/* type of an identifier */
+  Symbol *       baseType = nullptr;	/* base type, if extension */
+  Symbol *       value = nullptr;		/* value of a constant */
 				  
-  bool           complete;	/* used for top symbols only. */
-  unsigned       ifDepth;	/* depth of inheritance tree */
+  bool           complete;	  /* used for top symbols only. */
+  unsigned       ifDepth = 0;	/* depth of inheritance tree */
+                              /* depth 0 arbitrarily reserved */
 
-  unsigned       flags;		/* flags that govern code generation */
+  unsigned       flags = 0;		/* flags that govern code generation */
 
   LitValue       v;		/* only for sc_value and sc_builtin */
 
@@ -107,6 +109,10 @@ struct Symbol {
    * you have to do the scope push/pop by hand, which is at best
    * messy. Bother.
    */
+
+  // Public methods:
+  
+  InternedString QualifiedName(char sep);
 };
 
 #ifdef __cplusplus
@@ -127,8 +133,9 @@ Symbol *symbol_create(const char *nm, bool isActiveUOC, SymClass);
 Symbol *symbol_createPackage(const char *nm, Symbol *inPkg);
 Symbol *symbol_createRef(const char *nm, bool isActiveUOC);
 Symbol *symbol_createRef_inScope(const char *nm, bool isActiveUOC, Symbol *inScope);
+
+// Create a RaisesRef in scope symbol_curScope
 Symbol *symbol_createRaisesRef(const char *nm, bool isActiveUOC);
-Symbol *symbol_createRaisesRef_inScope(const char *nm, bool isActiveUOC, Symbol *inScope);
 Symbol *symbol_gensym(SymClass, bool isActiveUOC);
 Symbol *symbol_gensym_inScope(SymClass, bool isActiveUOC, Symbol *inScope);
   

--- a/src/build/src/capidl/capidl.cpp
+++ b/src/build/src/capidl/capidl.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the EROS Operating System runtime library.
  *
@@ -18,11 +19,10 @@
  * Foundation, 59 Temple Place - Suite 330 Boston, MA 02111-1307, USA.
  */
 
-/* GNU multiple precision library: */
 #include <sys/types.h>
 #include <errno.h>
 #include <getopt.h>
-#include <gmp.h>
+#include <gmp.h>  // GNU multiple precision library
 #include <malloc.h>
 #include <dirent.h>
 #include <string.h>
@@ -33,7 +33,6 @@
 #include <applib/Intern.h>
 #include <applib/PtrVec.h>
 #include <applib/path.h>
-/* #include <applib/Dictionary.h> */
 
 #include "SymTab.h"
 #include "ParseType.h"

--- a/src/build/src/capidl/o_c_hdr.cpp
+++ b/src/build/src/capidl/o_c_hdr.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
  * Copyright (C) 2006-2008, 2010, Strawberry Development Group.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the CapROS Operating System runtime library,
  * and is derived from the EROS Operating System runtime library.
@@ -683,10 +684,10 @@ symdump(Symbol *s, FILE *out, int indent)
 	      symbol_QualifiedName(s,'.'));
       
       /* Identify the exceptions raised at the interface level first: */
-      for(i = 0; i < vec_len(s->raises); i++) {
+      for (const auto eachRaised : s->raised) {
 	do_indent(out, indent+2);
 	fprintf(out, "/* interface raises %s */\n",
-		symbol_QualifiedName(symvec_fetch(s->raises,i),'_'));
+		eachRaised->QualifiedName('_') );
       }
 
       fprintf(out, "\n");
@@ -784,10 +785,10 @@ symdump(Symbol *s, FILE *out, int indent)
 
       fprintf(out, ");\n");
 
-      for(i = 0; i < vec_len(s->raises); i++) {
+      for (const auto eachRaised : s->raised) {
 	do_indent(out, indent + 2);
 	fprintf(out, "/* raises %s */\n" ,
-		symbol_QualifiedName(symvec_fetch(s->raises,i),'_'));
+		eachRaised->QualifiedName('_') );
       }
 
       print_asmendif(out);

--- a/src/build/src/capidl/o_capidl.cpp
+++ b/src/build/src/capidl/o_capidl.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the EROS Operating System runtime library.
  *
@@ -98,12 +99,12 @@ symdump(Symbol *s, int indent)
 	diag_printf("extends %s ", 
 		     symbol_QualifiedName(s->baseType,'.'));
 
-      if (vec_len(s->raises) != 0) {
-	unsigned i;
+      if (! s->raised.empty()) {
+	auto i = s->raised.size();	// number left to print
 	diag_printf("raises (");
-	for(i = 0; i < vec_len(s->raises); i++) {
-	  diag_printf((symvec_fetch(s->raises,i))->name);
-	  if (i != (vec_len(s->raises)-1))
+	for (const auto eachRaised : s->raised) {
+	  diag_printf(eachRaised->name);
+	  if (--i != 0)
 	    diag_printf(", ");
 	}
 
@@ -271,21 +272,18 @@ symdump(Symbol *s, int indent)
 	  diag_printf(",\n");
       }
 
-
-      if (vec_len(s->raises) > 0) {
-	unsigned i;
-
+      if (! s->raised.empty()) {
+	auto i = s->raised.size();	// number left to print
 	diag_printf(")\n");
 	do_indent(indent + 2);
 	diag_printf("(");
-	for (i = 0; i < vec_len(s->raises); i++) {
-	  diag_printf("%s", symbol_QualifiedName(symvec_fetch(s->raises,i),'_'));
-	  if (i != vec_len(s->raises)-1)
+	for (const auto eachRaised : s->raised) {
+	  diag_printf("%s", symbol_QualifiedName(eachRaised,'_'));
+	  if (--i != 0)
 	    diag_printf(", ");
 	}
+        diag_printf(");\n");
       }
-
-      diag_printf(");\n");
 
       break;
     }

--- a/src/build/src/capidl/o_symdump.cpp
+++ b/src/build/src/capidl/o_symdump.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the EROS Operating System runtime library.
  *
@@ -114,8 +115,8 @@ symdump(Symbol *s, int indent)
 	for(i = 0; i < vec_len(s->children); i++)
 	  symdump(symvec_fetch(s->children,i), indent + 2);
 
-	for(i = 0; i < vec_len(s->raises); i++)
-	  symdump(symvec_fetch(s->raises,i), indent + 2);
+  for (const auto eachRaised : s->raised)
+	  symdump(eachRaised, indent + 2);
 
 	do_indent(indent);
 	diag_printf("</%s>\n", symbol_ClassName(s));

--- a/src/build/src/capidl/o_xmldoc.cpp
+++ b/src/build/src/capidl/o_xmldoc.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2002, The EROS Group, LLC.
+ * Copyright (C) 2022, Charles Landau.
  *
  * This file is part of the EROS Operating System runtime library.
  *
@@ -118,8 +119,8 @@ symdump(Symbol *s, int indent)
 	for(i = 0; i < vec_len(s->children); i++)
 	  symdump(symvec_fetch(s->children,i), indent + 2);
 
-	for(i = 0; i < vec_len(s->raises); i++)
-	  symdump(symvec_fetch(s->raises,i), indent + 2);
+  for (const auto eachRaised : s->raised)
+    symdump(eachRaised, indent + 2);
 
 	do_indent(indent);
 	diag_printf("</%s>\n", symbol_ClassName(s));
@@ -146,8 +147,8 @@ symdump(Symbol *s, int indent)
 	for(i = 0; i < vec_len(s->children); i++)
 	  symdump(symvec_fetch(s->children,i), indent + 2);
 
-	for(i = 0; i < vec_len(s->raises); i++)
-	  symdump(symvec_fetch(s->raises,i), indent + 2);
+  for (const auto eachRaised : s->raised)
+    symdump(eachRaised, indent + 2);
 
 	do_indent(indent);
 	diag_printf("</%s>\n", symbol_ClassName(s));


### PR DESCRIPTION
Also:
Rename Symbol.raises to Symbol.raised to avoid conflict with a word that is used in text.
Give Symbol a proper constructor.
Change symbol_createRaisesRef_inScope to symbol_createRaisesRef since scope was always the same.
Fix a bug in symdump: close paren was output even if no exceptions are raised.