### PR TITLE
Add FormalSym as a subclass of Symbol, combining sc_formal and sc_outformal.

### DIFF
--- a/src/build/src/capidl/Lexer.h
+++ b/src/build/src/capidl/Lexer.h
@@ -1,7 +1,6 @@
 #include <applib/buffer.h>
 #include <capidl.h>
 
-typedef struct MyLexer MyLexer;
 struct MyLexer {
   InternedString current_file;
   InternedString current_basename;
@@ -19,7 +18,6 @@ void mylexer_setDebug(bool);
 void mylexer_ReportParseError(MyLexer *, const char * /* msg */);
 InternedString mylexer_grab_doc_comment(MyLexer *);
 
-typedef struct PrescanLexer PrescanLexer;
 struct PrescanLexer {
   InternedString pkgName;
   InternedString fileName;

--- a/src/build/src/capidl/ParseType.h
+++ b/src/build/src/capidl/ParseType.h
@@ -27,7 +27,6 @@
  * logic unhappy....
  */
 
-typedef struct Token Token;
 struct Token {
   /* Context at which token was found */
   InternedString file;
@@ -37,7 +36,6 @@ struct Token {
   InternedString is;
 };
 
-typedef struct ParseType ParseType;
 struct ParseType {
   Token     tok;		/* a literal string from the
 				 * tokenizer. Used for strings,

--- a/src/build/src/capidl/applib/App.cpp
+++ b/src/build/src/capidl/applib/App.cpp
@@ -27,12 +27,10 @@
 #include "xmalloc.h"
 #include "App.h"
 
-typedef struct FileList FileList;
 struct FileList {
   char* fileName;
   int isScratch;
   FileList* next;
-    
 } ;
 
 static struct {

--- a/src/build/src/capidl/applib/Intern.cpp
+++ b/src/build/src/capidl/applib/Intern.cpp
@@ -23,7 +23,6 @@
 #include "Intern.h"
 #include "xmalloc.h"
 
-typedef struct InternEntry InternEntry;
 struct InternEntry {
   InternEntry *pNext;
   unsigned signature;

--- a/src/build/src/capidl/applib/PtrVec.h
+++ b/src/build/src/capidl/applib/PtrVec.h
@@ -21,7 +21,6 @@
  * Foundation, 59 Temple Place - Suite 330 Boston, MA 02111-1307, USA.
  */
 
-typedef struct PtrVec PtrVec;
 struct PtrVec {
   unsigned      size;
   unsigned      maxSize;

--- a/src/build/src/capidl/applib/buffer.h
+++ b/src/build/src/capidl/applib/buffer.h
@@ -54,7 +54,6 @@ off_t buffer_length(const Buffer *);
 /* Extract a buffer that is a subrange of some existing buffer. */
 Buffer *buffer_fromBuffer(const Buffer *in, off_t start, off_t len);
 
-typedef struct BufferChunk BufferChunk;
 struct BufferChunk {
   const unsigned char *ptr;
   off_t len;

--- a/src/build/src/capidl/applib/sha1.h
+++ b/src/build/src/capidl/applib/sha1.h
@@ -32,7 +32,6 @@ typedef unsigned long long uint64_t;
 
 /* NOTE: If a pointer is ever added to this structure for some
  * reason, change sha_create() to use non-atomic malloc! */
-typedef struct SHA SHA;
 struct SHA {
   uint32_t h[5];		/* sha in progress */
   unsigned char block[BLKCHARS]; /* pending block */

--- a/src/build/src/capidl/backend.h
+++ b/src/build/src/capidl/backend.h
@@ -24,7 +24,6 @@ typedef void (*BackEndFn)(Symbol *);
 typedef bool (*BackEndCheckFn)(Symbol *);
 typedef void (*ScopeWalker)(Symbol *scope, BackEndFn outfn);
 
-typedef struct backend backend;
 struct backend {
   const char *name;
   BackEndCheckFn typecheck;

--- a/src/build/src/capidl/idl.y
+++ b/src/build/src/capidl/idl.y
@@ -1739,11 +1739,10 @@ param_list:
  */
 param:
         param_type name_def {
-          Symbol *sym;
           SHOWPARSE("param -> type name_def\n");
 
-	  sym = symbol_create($2.is, MYLEXER->isActiveUOC, sc_formal);
-	  if (sym == 0) {
+	  FormalSym * fsym = formalsym_create_inScope($2.is, MYLEXER->isActiveUOC, symbol_curScope);
+	  if (fsym == 0) {
 	    diag_printf("%s:%d: syntax error -- parameter identifier \"%s\" reused\n",
 			 MYLEXER->current_file, 
 			 MYLEXER->current_line,
@@ -1751,10 +1750,10 @@ param:
 	    num_errors++;
 	    YYERROR;
 	  }
-	  sym->type = $1;
-	  sym->docComment = mylexer_grab_doc_comment(lexer);
+	  fsym->type = $1;
+	  fsym->docComment = mylexer_grab_doc_comment(lexer);
 
-	  $$ = sym;
+	  $$ = fsym;
 	}
  ;
 
@@ -1806,7 +1805,7 @@ param_2:
         }
  |      OUT param {
           SHOWPARSE("param_2 -> OUT param\n");
-	  $2->cls = sc_outformal;
+	  $2->SetOutParam();
 	}
  ;
 

--- a/src/build/src/capidl/o_c_hdr.cpp
+++ b/src/build/src/capidl/o_c_hdr.cpp
@@ -687,10 +687,12 @@ symdump(Symbol *s, FILE *out, int indent)
 
       break;
     }
-  case sc_formal:
-  case sc_outformal:
+  case sc_ioformal:
     {
-      bool wantPtr = (s->cls == sc_outformal) || c_byreftype(s->type);
+      FormalSym * fsym = dynamic_cast<FormalSym*>(s);
+      assert(fsym);
+
+      bool wantPtr = fsym->isOutput || c_byreftype(s->type);
       wantPtr = wantPtr && !symbol_IsInterface(s->type);
 
       output_c_type(s->type, out, 0);

--- a/src/build/src/capidl/o_c_server_hdr.cpp
+++ b/src/build/src/capidl/o_c_server_hdr.cpp
@@ -97,6 +97,9 @@ emit_op_dispatcher(Symbol *s, FILE *outFile)
 
   bool first = true;
   for (const auto eachChild : s->children) {
+    FormalSym * fsym = dynamic_cast<FormalSym*>(eachChild);
+    assert(fsym);
+
     Symbol *argType = symbol_ResolveRef(eachChild->type);
     Symbol *argBaseType = symbol_ResolveType(argType);
     
@@ -105,7 +108,7 @@ emit_op_dispatcher(Symbol *s, FILE *outFile)
     else
       first = false;
     
-    if (eachChild->cls == sc_formal) {
+    if (! fsym->isOutput) {
       output_c_type(argBaseType, outFile, 0);
       fprintf(outFile, " %s", eachChild->name);
     } else {

--- a/src/build/src/capidl/o_c_util.cpp
+++ b/src/build/src/capidl/o_c_util.cpp
@@ -33,13 +33,17 @@ Approved for public release, distribution unlimited. */
 
 
 void
-extract_registerizable_arguments(Symbol * s, SymClass sc, std::vector<Symbol*> & regArgs)
+extract_registerizable_arguments(Symbol * s, bool output, std::vector<Symbol*> & regArgs)
 {
   unsigned nReg = FIRST_REG;
   unsigned needRegs;
 
   for (const auto eachChild : s->children) {
-    if (eachChild->cls != sc)
+    FormalSym * fsym = dynamic_cast<FormalSym*>(eachChild);
+    if (! fsym)
+      continue;
+
+    if (fsym->isOutput != output)
       continue;
 
     if (symbol_IsInterface(eachChild->type)) {
@@ -56,13 +60,17 @@ extract_registerizable_arguments(Symbol * s, SymClass sc, std::vector<Symbol*> &
 }
 
 void
-extract_string_arguments(Symbol * s , SymClass sc, std::vector<Symbol*> & stringArgs)
+extract_string_arguments(Symbol * s, bool output, std::vector<Symbol*> & stringArgs)
 {
   unsigned nReg = FIRST_REG;
   unsigned needRegs;
 
   for (const auto eachChild : s->children) {
-    if (eachChild->cls != sc)
+    FormalSym * fsym = dynamic_cast<FormalSym*>(eachChild);
+    if (! fsym)
+      continue;
+
+    if (fsym->isOutput != output)
       continue;
 
     if (symbol_IsInterface(eachChild->type))

--- a/src/build/src/capidl/o_c_util.h
+++ b/src/build/src/capidl/o_c_util.h
@@ -27,12 +27,12 @@
 /*
 Append the extracted Symbols to regArgs.
 */
-void extract_registerizable_arguments(Symbol *s, SymClass sc, std::vector<Symbol*> & regArgs);
+void extract_registerizable_arguments(Symbol *s, bool output, std::vector<Symbol*> & regArgs);
 
 /*
 Append the extracted Symbols to stringArgs.
 */
-void extract_string_arguments(Symbol *s, SymClass sc, std::vector<Symbol*> & stringArgs);
+void extract_string_arguments(Symbol *s, bool output, std::vector<Symbol*> & stringArgs);
 
 extern void output_c_type(Symbol *s, FILE *out, int indent);
 

--- a/src/build/src/capidl/o_capidl.cpp
+++ b/src/build/src/capidl/o_capidl.cpp
@@ -382,10 +382,10 @@ symdump(Symbol *s, int indent)
 	break;
     }
 
-  case sc_formal:
-  case sc_outformal:
+  case sc_ioformal:
     {
-      if (s->cls == sc_outformal)
+      FormalSym * fsym = dynamic_cast<FormalSym*>(s);
+      if (fsym->isOutput)
 	diag_printf("OUT ");
 
       symdump(s->type, 0);

--- a/src/build/src/capidl/o_symdump.cpp
+++ b/src/build/src/capidl/o_symdump.cpp
@@ -194,8 +194,7 @@ symdump(Symbol *s, int indent)
     }
 
   case sc_member:
-  case sc_formal:
-  case sc_outformal:
+  case sc_ioformal:
     {
       diag_printf("<%s name=\"%s\">\n", symbol_ClassName(s), 
 		   s->name);

--- a/src/build/src/capidl/o_xmldoc.cpp
+++ b/src/build/src/capidl/o_xmldoc.cpp
@@ -232,8 +232,7 @@ symdump(Symbol *s, int indent)
     }
 
   case sc_member:
-  case sc_formal:
-  case sc_outformal:
+  case sc_ioformal:
     {
       const char *type_name = s->type->name;
 

--- a/src/build/src/capidl/rewrite_c.cpp
+++ b/src/build/src/capidl/rewrite_c.cpp
@@ -46,7 +46,8 @@ fixup(Symbol *s)
       /* If the return type is non-void, stick it on the end of the
        * parameter list as an OUT parameter named "_retVal" */
       if (symbol_IsVoidType(s->type) == false) {
-	Symbol *retVal = symbol_create_inScope("_retVal", s->isActiveUOC, sc_outformal, s);
+	FormalSym * retVal = formalsym_create_inScope("_retVal", s->isActiveUOC, s);
+        retVal->SetOutParam();
 	retVal->type = s->type;
 	s->type = symbol_voidType;
       }
@@ -59,13 +60,15 @@ fixup(Symbol *s)
 
 	for (i = 0; i < s->children.size(); i++) {
 	  Symbol * child = s->children[i];
+          FormalSym * fsym = dynamic_cast<FormalSym*>(child);
+          assert(fsym);
 
-	  if (child->cls == sc_outformal && i < first_out) {
+	  if (fsym->isOutput && i < first_out) {
 	    first_out = i;
 	    continue;
 	  }
 
-	  if (child->cls == sc_formal && i > first_out) {
+	  if (! fsym->isOutput && i > first_out) {
 	    size_t j;
 	    for (j = i; j > first_out; j--)
               s->children[j] = s->children[j-1];

--- a/src/build/src/capidl/symclass.def
+++ b/src/build/src/capidl/symclass.def
@@ -3,6 +3,12 @@
   /* The following are all rvalues: */
 SYMCLASS(scope,1)		/* for scope records */
 SYMCLASS(builtin,0)		/* builtin constants */
+
+/* There is a design issue hiding here: how symbolic should the output
+ * of the IDL compiler be? I think the correct answer is "very", in
+ * which case we may need to do some tail chasing for constants. Thus,
+ * I consider a computed constant value to be a symbol.
+ */
 SYMCLASS(value,0)		/* computed constant values */ 
 
   /* The following define new names: */ 
@@ -20,8 +26,7 @@ SYMCLASS(package,1)		/* package name */
 SYMCLASS(member,0)		/* member field name */
 SYMCLASS(operation,1)		/* operation name */
 SYMCLASS(oneway,1)		/* oneway function name */
-SYMCLASS(formal,0)		/* formal parameter name */
-SYMCLASS(outformal,0)		/* OUT formal parameter name */
+SYMCLASS(ioformal,0)		/* formal parameter name */
 SYMCLASS(exception,1)		/* exception name */
 SYMCLASS(switch,1)		/* switch scope */
 SYMCLASS(caseScope,1)		/* implied case discriminator scope */


### PR DESCRIPTION
This allows Symbol.cls to be const.
Also remove typedefs no longer needed in C++.