### PR TITLE
No warning on gcc false positive in bison parser.

### DIFF
--- a/src/build/src/capidl/Makefile
+++ b/src/build/src/capidl/Makefile
@@ -82,7 +82,7 @@ $(BUILDDIR)/capidl: $(CAPIDL_OBJECTS) $(LIBS)
 	$(GPLUS) $(GPLUSFLAGS) -o $@ $(CAPIDL_OBJECTS) $(XENV_LIBDIR) $(LIBS) $(OTHER_LIBS)
 
 $(BUILDDIR)/idl.o: $(BUILDDIR)/idl.cpp
-	$(C_BUILD) 
+	$(GCC) $(GCCFLAGS) $(GCCWARN) -Wno-free-nonheap-object -c $< -o $@
 	$(C_DEP)
 
 $(BUILDDIR)/lex.o: lex.cpp $(BUILDDIR)/idl.h


### PR DESCRIPTION
Code generated from recent versions of bison will not compile under GCC 11.
The warning goes away at higher optimisation levels, but here we just disable
the warning.

c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753