### PR TITLE
node_Valid[Node]KeyPointer are required even without ddb

### DIFF
--- a/src/sys/kerninc/Key.h
+++ b/src/sys/kerninc/Key.h
@@ -120,9 +120,7 @@ bool CheckObjectType(OID oid, struct ObjectLocator * pObjLoc,
 #ifndef NDEBUG
 bool key_IsValid(const Key* thisPtr);
 #endif
-#ifdef OPTION_DDB
 int key_ValidKeyPtr(const Key * pKey);
-#endif
 
 void key_MakeUnpreparedCopy(Key * dst, const Key * src);
 

--- a/src/sys/kerninc/Node.h
+++ b/src/sys/kerninc/Node.h
@@ -104,9 +104,7 @@ void node_SetEqualTo(Node *thisPtr, const struct DiskNode *);
 void node_CopyToDiskNode(Node * pNode, struct DiskNode * dn);
 
 Node * node_ContainingNodeIfNodeKeyPtr(const Key * pKey);
-#ifdef OPTION_DDB
 Node * node_ValidNodeKeyPtr(const Key * pKey);
-#endif
 Node * node_ContainingNode(const Key * pKey);
 bool node_Validate(Node* thisPtr);
 


### PR DESCRIPTION
These functions appear to be used even when ddb is not configured.