### PR TITLE
ddb is badly bitrotten - disable it by default.

### DIFF
--- a/src/sys/arch/i486/conf/DEFAULT
+++ b/src/sys/arch/i486/conf/DEFAULT
@@ -21,7 +21,7 @@
 
 include("../../../config.common")
 
-option("ddb")
+#option("ddb")
 #option("output_on_tty0")
 
 # option("kern_profile")


### PR DESCRIPTION
Don't enable the kernel debugger in the default build.

This is a port of the Mach kernel debugger, and while it could be worthwhile to have, it will be a lot of work to get it compiling again.

In the meantime, you can always attach GDB to QEMU.