### PR TITLE
Remove unsupported target flags.

### DIFF
--- a/src/build/make/makevars.mk
+++ b/src/build/make/makevars.mk
@@ -58,8 +58,6 @@ endif
 ifeq ($(EROS_TARGET),i486)
 GOOD_TARGET=1
 # CapROS is still 32-bit only.
-TARGET_GCC_FLAGS+=-m32
-TARGET_LD_FLAGS+=-m elf_i386
 endif
 
 ifeq ($(EROS_TARGET),arm)


### PR DESCRIPTION
The cross compiler should already know what machine it targets and what linker script it emulates.
This code prevents correct linking, so remove it.

With this change, the first failure I get when building base is about a missing header in liblinuxk.  I'll try adding it and see how far I get.